### PR TITLE
Fluid icons are based off of unlocalized name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,12 +17,12 @@ buildscript {
 
 apply plugin: 'forge'
 
-version = "1.7.10-1.0.9"
+version = "1.7.10-1.0.10"
 group= "JSONAbles" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "{ JSONAbles }"
 
 minecraft {
-    version = "1.7.10-10.13.4.1448-1.7.10"
+    version = "1.7.10-10.13.4.1614-1.7.10"
     runDir = "eclipse"
 }
 
@@ -46,12 +46,12 @@ processResources
         exclude 'mcmod.info'
     }
 }
-repositories {
-    maven { // ttCore
-        name 'tterrag Repo'
-        url "http://maven.tterrag.com/"
-    }
-}
+// repositories {
+//     maven { // ttCore
+//         name 'tterrag Repo'
+//         url "http://maven.tterrag.com/"
+//     }
+// }
 dependencies {
     // you may put jars on which you depend on in ./libs
     // or you may define them like so..
@@ -65,7 +65,7 @@ dependencies {
     // for more info...
     // http://www.gradle.org/docs/current/userguide/artifact_dependencies_tutorial.html
     // http://www.gradle.org/docs/current/userguide/dependency_management.html
-	compile "tterrag.core:ttCore:MC${mc_version}-${ttCore_version}:deobf"	
+	//compile "tterrag.core:ttCore:MC${mc_version}-${ttCore_version}:deobf"	
 }
 task deobfJar(type: Jar) {
     from sourceSets.main.output

--- a/src/main/java/jsonAbles/blocks/MoltenFluid.java
+++ b/src/main/java/jsonAbles/blocks/MoltenFluid.java
@@ -15,8 +15,8 @@ import cpw.mods.fml.relauncher.SideOnly;
 public class MoltenFluid extends BlockFluidClassic {
 	public IIcon stillIcon;
 	public IIcon flowingIcon;
-	private String stillIconTexture = "liquid_gray";
-	private String flowIconTexture = "liquid_gray_flow";
+	private String stillIconTexture; // = "liquid_gray";
+	private String flowIconTexture; // = "liquid_gray_flow";
 	private Fluid fluid;
 	public int color;
 	public FluidSet set;
@@ -29,8 +29,8 @@ public class MoltenFluid extends BlockFluidClassic {
 		this.fluid = fluid;
 		String path = JsonAbles.configDir.getPath();
 		this.set = set;
-		this.stillIconTexture = (ModProps.modid + ":" + stillIconTexture);
-		this.flowIconTexture = (ModProps.modid + ":" + flowIconTexture);
+		this.stillIconTexture = (ModProps.modid + ":" + fluid.getUnlocalizedName());
+		this.flowIconTexture = (ModProps.modid + ":" + fluid.getUnlocalizedName() + "_flow");
 		this.color = color;
 	}
 

--- a/src/main/java/jsonAbles/config/ResourcePackAssembler.java
+++ b/src/main/java/jsonAbles/config/ResourcePackAssembler.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import lombok.AllArgsConstructor;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.FileResourcePack;
 import net.minecraft.client.resources.IResourcePack;
@@ -37,7 +36,6 @@ import cpw.mods.fml.relauncher.ReflectionHelper;
  */
 public class ResourcePackAssembler
 {
-    @AllArgsConstructor
     private class CustomFile
     {
         private String ext;


### PR DESCRIPTION
Also removed ttCore dependency, bumped mod version to 1.0.10, and forge version to 1614. 

This removes the default texture for fluids, instead using the unlocalized name as the basis for texture names (_unlocalizedname_.png and _unlocalizedname__flow.png). This means registered fluids without a custom texture will display the missing texture, but you can also have non-default textures now.

As this is a breaking change for existing users, I wouldn't necessarily merge the PR, but I wanted to create it for posterity.
